### PR TITLE
README Update for encrypted SSH key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ If you liked the project [docker-git2consul](https://github.com/Cimpress-MCP/doc
 *   CFG       - to replace the git2consul config.json  
 *   GIT_REPO  - to modify basic config with your git repo(basic config is listed below)  
 *   NAMESPACE - specifys the namespace your objects will come up in  
-*   ID        - base64 encoded string of your id_rsa key that is not password protected. (only used if using ssh for repo)  
-*   IDPUB     - base64 encoded string of your id_rsa.pub  
+*   ID        - your id_rsa key that is not password protected. (only used if using ssh for repo)  
+*   IDPUB     - string of your id_rsa.pub  
 *   CONSUL_ENDPOINT - configures what consul instance to hit  
 *   CONSUL_PORT - configures what consul instance's port to hit  
+*   IDENC -  base64 encoded string of your id_rsa key that is not password protected. (only used if using ssh for repo) 
+*   IDPUBENC - base64 encoded string of your id_rsa.pub  
 
 
 ### Docker Examples:
@@ -18,21 +20,30 @@ docker run \
         --env NAMESPACE=config \
         --env CONSUL_ENDPOINT=192.168.0.111 \
         --env CONSUL_PORT=8500 \
-        sroskelley/git2consul
+        gavinjonespf/docker-git2consul
 ```
 This will download the repo https://github.com/myuser/myrepo.git and feed it into the consul server located at 192.168.0.111:8500
 
 ```
-ID=$(cat ~/.ssh/id_rsa|base64)
-IDPUB=$(cat ~/.ssh/id_rsa.pub|base64)
+ID=$(cat ~/.ssh/id_rsa)
+IDPUB=$(cat ~/.ssh/id_rsa.pub)
+```
+OR
+```
+IDENC=$(cat ~/.ssh/id_rsa|base64)
+IDPUBENC=$(cat ~/.ssh/id_rsa.pub|base64)
+```
+THEN
+
+```
 CFG='{"version":"1.0","repos":[{"name":"config","url":"git@github.com:myrepo/configs.git","source_root":"dev","mountpoint":"","branches":["master"],"include_branch_name":false,"hooks":[{"type":"polling","interval":"1"}]}]}'
 docker run \
         --env CONSUL_ENDPOINT=192.168.0.111 \
-        --env CONSUL_PORT=8500
-        --env ID="$ID" \
-        --env IDPUB="$IDPUB"\
+        --env CONSUL_PORT=8500 \
+        OR --env ID="$ID" --env IDPUB="$IDPUB"\
+        OR --env IDENC="$IDENC" --env IDPUBENC="$IDPUBENC"\
         --env CFG="$CFG" \
-        sroskelley/git2consul
+        gavinjonespf/docker-git2consul
 ```
 This shows how to manually specify your own config and use ssh keys to connect to the git repo. 
 

--- a/README.md
+++ b/README.md
@@ -27,24 +27,29 @@ This will download the repo https://github.com/myuser/myrepo.git and feed it int
 ```
 ID=$(cat ~/.ssh/id_rsa)
 IDPUB=$(cat ~/.ssh/id_rsa.pub)
+CFG='{"version":"1.0","repos":[{"name":"config","url":"git@github.com:myrepo/configs.git","source_root":"dev","mountpoint":"","branches":["master"],"include_branch_name":false,"hooks":[{"type":"polling","interval":"1"}]}]}'
+docker run \
+        --env CONSUL_ENDPOINT=192.168.0.111 \
+        --env CONSUL_PORT=8500 \
+        --env ID="$ID" \
+        --env IDPUB="$IDPUB" \
+        --env CFG="$CFG" \
+        gavinjonespf/docker-git2consul
 ```
 OR
 ```
 IDENC=$(cat ~/.ssh/id_rsa|base64)
 IDPUBENC=$(cat ~/.ssh/id_rsa.pub|base64)
-```
-THEN
-
-```
 CFG='{"version":"1.0","repos":[{"name":"config","url":"git@github.com:myrepo/configs.git","source_root":"dev","mountpoint":"","branches":["master"],"include_branch_name":false,"hooks":[{"type":"polling","interval":"1"}]}]}'
 docker run \
         --env CONSUL_ENDPOINT=192.168.0.111 \
         --env CONSUL_PORT=8500 \
-        OR --env ID="$ID" --env IDPUB="$IDPUB"\
-        OR --env IDENC="$IDENC" --env IDPUBENC="$IDPUBENC"\
+        --env IDENC="$IDENC" \
+        --env IDPUBENC="$IDPUBENC" \
         --env CFG="$CFG" \
         gavinjonespf/docker-git2consul
 ```
+
 This shows how to manually specify your own config and use ssh keys to connect to the git repo. 
 
 


### PR DESCRIPTION
init.sh contains this:
```
if [ -n "$IDENC" ]
then
  ID=$(echo $IDENC |base64 -d)
  IDPUB=$(echo $IDPUBENC |base64 -d)
fi
```
And the README.md said that to use base64 encoded values in ```ID``` and ```IDPUB``` environment variables and that is wrong! These fields need pure raw ssh keys, if you want to use base64 encoded values please use the ```IDENC``` and ```IDPUBENC``` for safety.